### PR TITLE
adding parents and changes to commits, and updating schema to fix issues

### DIFF
--- a/tap_azure_git/__init__.py
+++ b/tap_azure_git/__init__.py
@@ -158,7 +158,7 @@ def authed_get(source, url, headers={}):
     with metrics.http_request_timer(source) as timer:
         session.headers.update(headers)
         # Uncomment for debugging
-        logger.info("requesting {}".format(url))
+        #logger.info("requesting {}".format(url))
         resp = session.request(method='get', url=url)
         if resp.status_code != 200:
             raise_for_error(resp, source)
@@ -317,7 +317,6 @@ def get_all_commits(schema, org, repo_path, state, mdata, start_date):
     bookmark = get_bookmark(state, repo_path, "commits", "since", start_date)
     if not bookmark:
         bookmark = '1970-01-01'
-    bookmark = '1970-01-01'
 
     with metrics.record_counter('commits') as counter:
         extraction_time = singer.utils.now()

--- a/tap_azure_git/schemas/commits.json
+++ b/tap_azure_git/schemas/commits.json
@@ -124,12 +124,6 @@
             "number"
           ]
         },
-        "Branch": {
-          "type": [
-            "null",
-            "number"
-          ]
-        },
         "Delete": {
           "type": [
             "null",
@@ -142,60 +136,27 @@
             "number"
           ]
         },
-        "Encoding": {
-          "type": [
-            "null",
-            "number"
-          ]
-        },
-        "Lock": {
-          "type": [
-            "null",
-            "number"
-          ]
-        },
-        "Merge": {
-          "type": [
-            "null",
-            "number"
-          ]
-        },
-        "Property": {
-          "type": [
-            "null",
-            "number"
-          ]
-        },
         "Rename": {
           "type": [
             "null",
             "number"
           ]
         },
-        "Rollback": {
+        "Delete, SourceRename": {
           "type": [
             "null",
             "number"
           ]
         },
-        "SourceRename": {
-          "type": [
-            "null",
-            "number"
-          ]
-        },
-        "TargetRename": {
-          "type": [
-            "null",
-            "number"
-          ]
-        },
-        "Undelete": {
+        "Edit, Rename": {
           "type": [
             "null",
             "number"
           ]
         }
+      },
+      "patternProperties": {
+        ".+": {}
       }
     },
     "GitPushRef": {
@@ -266,13 +227,6 @@
     "GitChange": {
       "type": ["null", "object"],
       "properties": {
-        "changeId": {
-          "type": [
-            "null",
-            "number"
-          ],
-          "description": "ID of the change within the group of changes."
-        },
         "changeType": {
           "type": [
             "null",
@@ -280,33 +234,59 @@
           ],
           "description": "The type of change that was made to the item."
         },
-        "item": {
-          "type": [
-            "null",
-            "string"
-          ],
-          "description": "Current version."
-        },
-        "originalPath": {
-          "type": [
-            "null",
-            "string"
-          ],
-          "description": "Original path of item if different from current path."
-        },
         "sourceServerItem": {
           "type": [
             "null",
             "string"
           ],
-          "description": "Path of the item on the server."
+          "description": "The original path to the item if it has changed."
         },
-        "url": {
-          "type": [
-            "null",
-            "string"
-          ],
-          "description": "URL to retrieve the item."
+        "item": {
+          "type": ["null", "object"],
+          "properties": {
+            "objectId": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "originalObjectId": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "gitObjectType": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "path": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "isFolder": {
+              "type": [
+                "null",
+                "boolean"
+              ]
+            },
+            "commitId": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "url": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
Adds requests to get commit parents and changes.

## How was this tested?
- Ran locally and verified that parents and changes are populated correctly
- Tested with low page size to ensure that multiple pages of changes were all fetched.