### PR TITLE
Kevin/2021 08 23 mw 71 add pr schema

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ setup(name='tap-azure-git',
       py_modules=['tap_azure_git'],
       install_requires=[
           'singer-python==5.12.1',
-          'requests==2.20.0'
+          'requests==2.20.0',
+          'dateutil==2.8.2'
       ],
       extras_require={
           'dev': [

--- a/tap_azure_git/schemas/pull_requests.json
+++ b/tap_azure_git/schemas/pull_requests.json
@@ -226,7 +226,7 @@
     }
   },
   "definitions": {
-    "IdentifyRef": {
+    "IdentityRef": {
       "type": ["null", "object"],
       "properties": {
         "id": {


### PR DESCRIPTION
Adds pull requests to the schema, including a list of PR commit IDs.

## How was this tested?
- Ran locally to verify that all pull requests and child objects were imported properly into the database.
- Verified that PRs closed before the bookmark date were skipped
- Verified correct paging behavior by setting the page size to 1 instead of 100 and checking that multiple pull requests were imported.