### PR TITLE
MW-83 - adding logic to import patches

### DIFF
--- a/tap_azure_git/schemas/commits.json
+++ b/tap_azure_git/schemas/commits.json
@@ -292,6 +292,24 @@
                 "null",
                 "string"
               ]
+            },
+            "patch": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "isBinary": {
+              "type": [
+                "null",
+                "boolean"
+              ]
+            },
+            "isLargeFile": {
+              "type": [
+                "null",
+                "boolean"
+              ]
             }
           }
         }


### PR DESCRIPTION
Adding patches to imported file changes by grabbing and diffing the raw blobs

## How was this tested?
- Checked cache hits by logging hit/miss for importing the whole "scheduled" repo and observed cache hits
- Tested hardcoding string to have null byte to verify that it is recognized as binary
- Tested hardcoding string to have invalid utf-8 characters to verify that it is recognized as binary
- Ran on whole 'scheduled' repo, verified that data imported correctly into the database (`select item__objectid, item__path, char_length(item__patch) from s_azuregit_3.commits__changes where _sdc_source_key_commitid='4e28eb03bc39979f86067fc2e92a8cedd22c6535'`)
- Didn't test the diff code itself since it was copied directly from the github repo.
- After merging, will test in production, replacing current schema.