### PR TITLE
Kevin/2022 09 20 mw 752 commit files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ setup(name='tap-azure-git',
       py_modules=['tap_azure_git'],
       install_requires=[
           'singer-python==5.12.1',
-          'requests==2.20.0'
+          'requests==2.20.0',
+          'psutil==5.8.0'
       ],
       extras_require={
           'dev': [

--- a/tap_azure_git/__init__.py
+++ b/tap_azure_git/__init__.py
@@ -682,7 +682,6 @@ def get_all_heads_for_commits(repo_path):
     return head_set
     '''
 
-
 def get_all_commit_files(schemas, org, repo_path, state, mdata, start_date, gitLocal):
     '''
     repo_path should be the full _sdc_repository path of {org}/{project}/_git/{repo}

--- a/tap_azure_git/__init__.py
+++ b/tap_azure_git/__init__.py
@@ -1024,7 +1024,7 @@ def do_sync(config, state, catalog):
 
     domain = config['pull_domain'] if 'pull_domain' in config else 'dev.azure.com'
     gitLocal = GitLocal({
-        'access_token': config['private_token'],
+        'access_token': config['access_token'],
         'workingDir': '/tmp',
     }, 'https://{}@' + domain + '/{}', # repo is format: {org}/{project}/_git/{repo}
         config['hmac_token'] if 'hmac_token' in config else None)

--- a/tap_azure_git/schemas/commits.json
+++ b/tap_azure_git/schemas/commits.json
@@ -13,16 +13,6 @@
       "$ref": "ChangeCountDictionary",
       "description": "Counts of the types of changes (edits, deletes, etc.) included with the commit."
     },
-    "changes": {
-      "type": [
-        "null",
-        "array"
-      ],
-      "items": {
-        "$ref": "GitChange"
-      },
-      "description": "An enumeration of the changes included with the commit."
-    },
     "comment": {
       "type": ["null", "string"],
       "description": "Comment or message of the commit."
@@ -228,90 +218,6 @@
             "string"
           ],
           "description": "This url is the full route to the source resource of this graph subject."
-        }
-      }
-    },
-    "GitChange": {
-      "type": ["null", "object"],
-      "properties": {
-        "changeType": {
-          "type": [
-            "null",
-            "string"
-          ],
-          "description": "The type of change that was made to the item."
-        },
-        "sourceServerItem": {
-          "type": [
-            "null",
-            "string"
-          ],
-          "description": "The original path to the item if it has changed."
-        },
-        "item": {
-          "type": ["null", "object"],
-          "properties": {
-            "objectId": {
-              "type": [
-                "null",
-                "string"
-              ]
-            },
-            "originalObjectId": {
-              "type": [
-                "null",
-                "string"
-              ]
-            },
-            "gitObjectType": {
-              "type": [
-                "null",
-                "string"
-              ]
-            },
-            "path": {
-              "type": [
-                "null",
-                "string"
-              ]
-            },
-            "isFolder": {
-              "type": [
-                "null",
-                "boolean"
-              ]
-            },
-            "commitId": {
-              "type": [
-                "null",
-                "string"
-              ]
-            },
-            "url": {
-              "type": [
-                "null",
-                "string"
-              ]
-            },
-            "patch": {
-              "type": [
-                "null",
-                "string"
-              ]
-            },
-            "isBinary": {
-              "type": [
-                "null",
-                "boolean"
-              ]
-            },
-            "isLargeFile": {
-              "type": [
-                "null",
-                "boolean"
-              ]
-            }
-          }
         }
       }
     },


### PR DESCRIPTION
Updates the Azure Git tap to load file data from GitLocal and emit it in commit_files + refs schemas. (It no longer emits file changes in the original commits schema.)

## How was this tested?
- Ran locally to verify that all of the commits and refs were picked up by commit_files as expected.
- Verified that re-run didn't emit new commit_files based on state