### PR TITLE
adding repositories and process globals flag

### DIFF
--- a/tap_azure_git/schemas/repositories.json
+++ b/tap_azure_git/schemas/repositories.json
@@ -1,0 +1,43 @@
+{
+  "type": ["null", "object"],
+  "properties": {
+    "_sdc_repository": {
+      "type": ["string"],
+      "description": "Unique string identifying the repository in the format {org}/{project}/_git/{repository}"
+    },
+    "id": {
+      "type": ["null", "string"],
+      "description": "UUID of the repository"
+    },
+    "name": {
+      "type": ["null", "string"],
+      "description": "Name of the repository"
+    },
+    "defaultBranch": {
+      "type": ["null", "string"],
+      "description": "Default branch of the repository, starts with 'refs/heads'"
+    },
+    "isDisabled": {
+      "type": ["null", "boolean"],
+      "description": "Is the repository disabled?"
+    },
+    "project": {
+      "type": ["null", "object"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": ["null", "string"],
+          "description": "UUID of the project"
+        },
+        "name": {
+          "type": ["null", "string"],
+          "description": "Name of the project"
+        },
+        "visibility": {
+          "type": ["null", "string"],
+          "description": "Visibility of the project, one of: public, private"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## How was this tested?
- Ran against repotest to verify all repositories were emitted when process_globals was missing, and none were emitted when it was set to false.