### PR TITLE
Kevin/2022 09 22 mw 755 fix hmac

### DIFF
--- a/tap_azure_git/gitlocal.py
+++ b/tap_azure_git/gitlocal.py
@@ -43,7 +43,7 @@ def hashPatchLine(patchLine, hmacToken = None):
         patchLine == '-' or \
         patchLine == '+ ' or \
         patchLine == '- ' or \
-        patchLine == '\ No newline at end of file':
+        '\\ No newline at end of file' in patchLine:
       return patchLine
     prefix = ''
     if patchLine[0] == '+' or patchLine[0] == '-' or patchLine[0] == ' ':

--- a/tap_azure_git/gitlocal.py
+++ b/tap_azure_git/gitlocal.py
@@ -2,10 +2,7 @@
 # https://minware.atlassian.net/browse/MW-258
 
 import subprocess
-import sys
 import os
-import re
-import json
 import singer
 import hashlib
 
@@ -45,7 +42,7 @@ def hashPatchLine(patchLine, hmacToken = None):
     if patchLine[0] == '+' or patchLine[0] == '-':
       prefix = patchLine[0]
       patchLine = patchLine[1:]
-    return ''.join([prefix, computeHmac(patchLine, hmacToken)])
+    return ''.join([prefix, computeHmac(patchLine, hmacToken) if len(patchLine) > 0 else ''])
 
 
 def parseDiffLines(lines, shouldEncrypt=False, hmacToken=None):

--- a/tap_azure_git/gitlocal.py
+++ b/tap_azure_git/gitlocal.py
@@ -38,11 +38,18 @@ def hashPatchLine(patchLine, hmacToken = None):
     else:
       return '@@'.join([header, ' ' + computeHmac(context[1:], hmacToken)])
   else:
+    if patchLine == '' or \
+        patchLine == '+' or \
+        patchLine == '-' or \
+        patchLine == '+ ' or \
+        patchLine == '- ' or \
+        patchLine == '\ No newline at end of file':
+      return patchLine
     prefix = ''
-    if patchLine[0] == '+' or patchLine[0] == '-':
+    if patchLine[0] == '+' or patchLine[0] == '-' or patchLine[0] == ' ':
       prefix = patchLine[0]
       patchLine = patchLine[1:]
-    return ''.join([prefix, computeHmac(patchLine, hmacToken) if len(patchLine) > 0 else ''])
+    return ''.join([prefix, computeHmac(patchLine, hmacToken)])
 
 
 def parseDiffLines(lines, shouldEncrypt=False, hmacToken=None):


### PR DESCRIPTION
Fixes how the HMAC was getting replaced to not step on stuff that is part of the diff syntax.

## How was this tested?
- Re-ran on repotest to verify that there weren't any parse patch failures on the HMAC'd diffs.