### PR TITLE
Change repository option to allow a string or a json array

### DIFF
--- a/tap_azure_git/__init__.py
+++ b/tap_azure_git/__init__.py
@@ -987,7 +987,7 @@ def do_sync(config, state, catalog):
 
     org = config['org']
 
-    repositories = list(filter(None, config['repository'].split(' ')))
+    repositories = [config['repository']] if isinstance(config['repository'], str) else config['repository']
 
 
     domain = config['pull_domain'] if 'pull_domain' in config else 'dev.azure.com'


### PR DESCRIPTION

## How was this tested
- [x] Reproduced failure locally
- [x] Logged repositories to verify the split was causing problems
- [x] Re-ran after making these changes, verified tap ran to completion