### PR TITLE
Add annotated tags, use new gitlocal api to fetch annotated tags and save them

### DIFF
--- a/tap_azure_git/schemas/annotated_tags.json
+++ b/tap_azure_git/schemas/annotated_tags.json
@@ -1,0 +1,78 @@
+{
+  "type": [
+    "null",
+    "object"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "_sdc_repository": {
+      "type": [
+        "string"
+      ]
+    },
+    "tagger": {
+      "$ref": "GitUserDate",
+      "description": "Author of the tag."
+    },
+    "message": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "description": "message of the annotated tag."
+    },
+    "name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "tagId": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "description": "ID (SHA-1) of the tag."
+    },
+    "commitId": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "description": "ID (SHA-1) of the commit this tag points to."
+    }
+  },
+  "definitions": {
+    "GitUserDate": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "date": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time",
+          "description": "Date of the Git operation."
+        },
+        "email": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "Email address of the user performing the Git operation."
+        },
+        "name": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "description": "Name of the user performing the Git operation."
+        }
+      }
+    }
+  }
+}

--- a/tap_azure_git/schemas/refs.json
+++ b/tap_azure_git/schemas/refs.json
@@ -11,6 +11,11 @@
     "sha": {
       "type": ["null", "string"],
       "description": "The ref's commit hash"
+    },
+    "type": {
+      "type": ["null", "string"],
+      "enum": ["commit", "tag"],
+      "description": "The type of object this ref points to"
     }
   }
 }


### PR DESCRIPTION
## How was this tested
- [x] Ran against repo that used annotated tags, verified refs and annotated tags were pushed to snowflake

Depends on https://github.com/minwareco/gitlocal/pull/8 