### PR TITLE
implement commit only mode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import setup, find_packages
 
-UTILS_VERSION = "52a7ce3dbe9b96a6a09e9e9ce029b2840a9eb937"
+UTILS_VERSION = "21a1d4b552e2a821f9414bd9a35377e5892a260b"
 
 setup(name='tap-azure-git',
       version='0.1',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import setup, find_packages
 
-UTILS_VERSION = "955a167aefb67b957ee2eea2369327111f8bd802"
+UTILS_VERSION = "52a7ce3dbe9b96a6a09e9e9ce029b2840a9eb937"
 
 setup(name='tap-azure-git',
       version='0.1',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import setup, find_packages
 
-UTILS_VERSION = "5114b38b4bca476e2312035226b9a5a65b5c2cdb"
+UTILS_VERSION = "955a167aefb67b957ee2eea2369327111f8bd802"
 
 setup(name='tap-azure-git',
       version='0.1',

--- a/tap_azure_git/__init__.py
+++ b/tap_azure_git/__init__.py
@@ -1463,12 +1463,12 @@ def do_sync(config, state, catalog):
                                                 sub_stream['key_properties'])
 
                     # sync stream and its sub streams
-                    if stream_id == 'commit_files' or stream_id == 'commit_files_meta':
+                    if stream_id == 'commit_files':
                         heads = get_pull_request_heads(org, repo)
                         # We don't need to also get open branch heads here becuase those are
                         # included in the git clone --mirror, though PR heads for merged PRs are
                         # not included.
-                        commits_only = stream_id == 'commit_files_meta'
+                        commits_only = False
                         state = sync_func(stream_schemas, org, repo, state, mdata, start_date,
                             gitLocal, heads, commits_only, selected_stream_ids)
                     else:

--- a/tap_azure_git/__init__.py
+++ b/tap_azure_git/__init__.py
@@ -1446,10 +1446,6 @@ def do_sync(config, state, catalog):
                         commits_only = True
                         heads = get_pull_request_heads(org, repo)
                         stream_schemas = {stream_id: stream_schema}
-                        # Add refs schema if refs stream is selected
-                        if 'refs' in selected_stream_ids:
-                            refs_stream = get_stream_from_catalog('refs', catalog)
-                            stream_schemas['refs'] = refs_stream['schema']
                         state = sync_func(stream_schemas, org, repo, state, mdata, start_date, gitLocal, heads, commits_only, selected_stream_ids)
                     else:
                         state = sync_func(stream_schema, org, repo, state, mdata, start_date)

--- a/tap_azure_git/__init__.py
+++ b/tap_azure_git/__init__.py
@@ -1356,7 +1356,7 @@ SYNC_FUNCTIONS = {
 
 SUB_STREAMS = {
     'pull_requests': ['pull_request_threads'],
-    'commit_files': ['annotated_tags', 'refs'],
+    'commit_files': ['refs', 'annotated_tags'],
     'builds': ['build_timelines'],
     'pipelines': ['runs']
 }

--- a/tap_azure_git/__init__.py
+++ b/tap_azure_git/__init__.py
@@ -1356,7 +1356,8 @@ SYNC_FUNCTIONS = {
 
 SUB_STREAMS = {
     'pull_requests': ['pull_request_threads'],
-    'commit_files': ['refs', 'annotated_tags'],
+    'commit_files': ['annotated_tags'],
+    'commit_files_meta': ['refs'],
     'builds': ['build_timelines'],
     'pipelines': ['runs']
 }

--- a/tap_azure_git/schemas/commit_files_meta.json
+++ b/tap_azure_git/schemas/commit_files_meta.json
@@ -1,0 +1,124 @@
+{
+  "type": ["null", "object"],
+  "properties": {
+    "_sdc_repository": {
+      "type": ["string"]
+    },
+    "id": {
+      "type": ["null", "string"],
+      "description": "Unique identifier of commit, <_sdc_repository>/<sha>"
+    },
+    "sha": {
+      "type": ["null", "string"],
+      "description": "The git commit hash"
+    },
+    "parents": {
+      "type": ["null", "array"],
+      "items": {
+        "type": ["null", "object"],
+        "additionalProperties": false,
+        "properties": {
+          "sha": {
+            "type": ["null", "string"],
+            "description": "The git hash of the parent commit"
+          }
+        }
+      }
+    },
+    "commit": {
+      "type": ["null", "object"],
+      "properties": {
+        "tree": {
+          "type": ["null", "object"],
+          "properties": {
+            "sha": {
+              "type": ["null", "string"]
+            }
+          }
+        },
+        "author": {
+          "type": ["null", "object"],
+          "additionalProperties": false,
+          "properties": {
+            "date": {
+              "type": ["null", "string"],
+              "format": "date-time",
+              "description": "The date the author committed the change"
+            },
+            "name": {
+              "type": ["null", "string"],
+              "description": "The author's name"
+            },
+            "email": {
+              "type": ["null", "string"],
+              "description": "The author's email"
+            }
+          }
+        },
+        "message": {
+          "type": ["null", "string"],
+          "description": "The commit message"
+        },
+        "committer": {
+          "type": ["null", "object"],
+          "additionalProperties": false,
+          "properties": {
+            "date": {
+              "type": ["null", "string"],
+              "format": "date-time",
+              "description": "The date the committer committed the change"
+            },
+            "name": {
+              "type": ["null", "string"],
+              "description": "The committer's name"
+            },
+            "email": {
+              "type": ["null", "string"],
+              "description": "The committer's email"
+            }
+          }
+        }
+      }
+    },
+    "files": {
+      "type": ["array"],
+      "items": {
+        "type": ["null", "object"],
+        "properties": {
+          "filename": {
+            "type": ["string"],
+            "description": "The full name of the file including its directory path, unique per commit"
+          },
+          "previous_filename": {
+            "type": ["null", "string"],
+            "description": "If the file was renamed, this was its full name in the parent commit"
+          },
+          "patch": {
+            "type": ["null", "string"],
+            "description": "A patch representing the changes to the file in this commit."
+          },
+          "is_binary": {
+            "type": ["boolean"],
+            "description": "The file is binary, so no patch is included and change counts are zero. Binary is determined by the presence of null bytes or sequences that cause UTF-8 decoding errors. This flag will not be set when adding binary files becuase those are indiscernable from adding zero-length files in the github api."
+          },
+          "is_large_patch": {
+            "type": ["boolean"],
+            "description": "The file is text, but the current patch was too large to include (> 1 MB). Change counts may or may not be non-zero."
+          },
+          "changetype": {
+            "type": ["string"],
+            "description": "The type of change -- one of: add, delete, edit, none. None means no change to the file, which may be the case if there's a rename."
+          },
+          "additions": {
+            "type": ["integer"],
+            "description": "The number of lines added by this change (0 for binary or large patch)."
+          },
+          "deletions": {
+            "type": ["integer"],
+            "description": "The number of lines deleted by this change (0 for binary or large patch)."
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This change allows us to process the commit files meta job.

I have validated this by running commit files meta and commit files jobs and observed that the files make it into S3.