### PR TITLE
handle gitlocal error and update logging

### DIFF
--- a/tap_azure_git/__init__.py
+++ b/tap_azure_git/__init__.py
@@ -594,24 +594,18 @@ def get_all_commits(schema, org, repo_path, state, mdata, start_date):
 
 
 def get_commit_detail_local(commit, gitLocalRepoPath, gitLocal):
-    commit_sha = commit['sha']
-    logger.debug(f"Processing commit diff for SHA: {commit_sha}")
-    
     try:
-        changes = gitLocal.getCommitDiff(gitLocalRepoPath, commit_sha)
+        changes = gitLocal.getCommitDiff(gitLocalRepoPath, commit['sha'])
         commit['files'] = changes
-        logger.debug(f"Successfully processed diff for commit {commit_sha}, found {len(changes)} file changes")
     except GitLocalException as e:
         # Handle cases where commits cannot be fetched from Azure DevOps
         # This commonly happens with deleted PRs or inaccessible objects
-        logger.warning(f"GitLocalException caught for commit {commit_sha} in repo {gitLocalRepoPath}: {str(e)}")
-        logger.info(f"Continuing sync with empty file list for commit {commit_sha}")
+        logger.info(f"Failed to get diff for commit {commit['sha']} in repo {gitLocalRepoPath}, continuing with empty file list: {str(e)}")
         commit['files'] = []
     except Exception as e:
         # This generally shouldn't happen since we've already fetched and checked out the head
         # commit successfully, so it probably indicates some sort of system error. Just let it
         # bubble up for now.
-        logger.error(f"Unexpected error processing commit {commit_sha}: {str(e)}")
         raise e
 
 def get_commit_changes(commit, sdcRepository, gitLocalRepoPath, gitLocal):


### PR DESCRIPTION
This change is effectively a change to logging from what's in master, but should be reviewed in conjunction with the change in https://github.com/minwareco/tap-azure-git/commit/b71c7df8ebc196d865a097f56f579c2ce2c0d85c which changes the behavior to handle the error thrown when the sha can't be found.

We're getting what seems error where a commit can't be found with logs like this:
minware_singer_utils.gitlocal.GitLocalException: Diff of repo <redacted> 93f7c588172766ce781a15876245f1580271d73b failed with code 128, message: fatal: git fetch-pack: expected ACK/NAK, got '?TF401035: The object '4d4953102e467a7973aa8e093b91541eaeeda908' does not exist.'
fatal: the remote end hung up unexpectedly
fatal: could not fetch 4d4953102e467a7973aa8e093b91541eaeeda908 from promisor remote

I contemplated making this change in gitLocal itself, but since this seems like an ADO specific thing, I opted to make it directly in the tap.

This is really weird. I see this happening in production, but then when I run the job that failed locally, it works. In production, the ingest job for the same repo has failed multiple times but with different shas which cannot be found. 
