### PR TITLE
update minware-singer-utils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import setup, find_packages
 
-UTILS_VERSION = "e99e96ad3012b67e542590464a307ab05bff7f7a"
+UTILS_VERSION = "756eaa55ae05c44a58124a26e839698c2f5b78cc"
 
 setup(name='tap-azure-git',
       version='0.1',


### PR DESCRIPTION
Update minware-singer-utils to get the clone retry update. Tested with https://github.com/minwareco/minware-singer-utils/pull/16