### PR TITLE
MW-9369: Use environment variable for minware-singer-utils version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 
 from setuptools import setup, find_packages
 
-UTILS_VERSION = "756eaa55ae05c44a58124a26e839698c2f5b78cc"
+UTILS_VERSION = os.environ.get("UTILS_VERSION")
 
 setup(name='tap-azure-git',
       version='0.1',


### PR DESCRIPTION
Use UTILS_VERSION environment variable to control minware-singer-utils version dynamically